### PR TITLE
Fix setting open string as invalid root note

### DIFF
--- a/internals/render/renderFretString.go
+++ b/internals/render/renderFretString.go
@@ -24,7 +24,7 @@ func RenderFretString(fretString frets.NeckString, from int, to int, fret string
 	case "x":
 		renderString = renderString + initMutedString(stringPosition, isNut, style)
 	case "0":
-		renderString = renderString + initOpenString(stringPosition, isNut, style, isStringRoot)
+		renderString = renderString + initOpenString(stringPosition, isNut, style, isStringRoot && isRootNoteValid)
 	default:
 		renderString = renderString + initString(stringPosition, isNut, style)
 	}


### PR DESCRIPTION
There was a bug here where if the root note is invalid on line 16, then `rootNote` is 0, which from `rootNote.String()` becomes the first note in the map, namely "A". Then the open string, "A", is highlighted red when it shouldn't be.